### PR TITLE
Handle disconnects and update routes

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -55,42 +55,42 @@ const App: React.FC<AppProps> = ({ model }) => {
             path="/profile"
             element={<ProfilePage handleLogout={handleLogout} />} 
           />
-          <Route 
-            path="/host-game" 
-            element={<HostWaiting model={model} />} 
-          />
-          <Route 
-            path="/host-ingame" 
-            element={<HostGame model={model} />} 
-          />
-          <Route 
-            path="/host-voting" 
-            element={<HostVote model={model} />} 
-          />
-          <Route 
-            path="/host-results" 
-            element={<HostEnd model={model} />} 
-          />
-          <Route 
-            path="/player-waiting" 
-            element={<PlayerWaiting model={model} />} 
-          />
-          <Route 
-            path="/player-game" 
-            element={<PlayerGame model={model} />} 
-          />
-          <Route 
-            path="/player-ingame" 
-            element={<PlayerGame model={model} />} 
-          />
-          <Route 
-            path="/player-voting" 
-            element={<PlayerVote model={model} />} 
-          />
-          <Route 
-            path="/player-results" 
-            element={<PlayerEnd model={model} />} 
-          />
+          <Route path="/host">
+            <Route 
+              path="game" 
+              element={<HostWaiting model={model} />} 
+            />
+            <Route 
+              path="ingame" 
+              element={<HostGame model={model} />} 
+            />
+            <Route 
+              path="voting" 
+              element={<HostVote model={model} />} 
+            />
+            <Route 
+              path="results" 
+              element={<HostEnd model={model} />} 
+            />
+          </Route>
+          <Route path="/player">
+            <Route 
+              path="game" 
+              element={<PlayerWaiting model={model} />} 
+            />
+            <Route 
+              path="ingame" 
+              element={<PlayerGame model={model} />} 
+            />
+            <Route 
+              path="voting" 
+              element={<PlayerVote model={model} />} 
+            />
+            <Route 
+              path="results" 
+              element={<PlayerEnd model={model} />} 
+            />
+          </Route>
           <Route path="*" element={<Navigate to="/homepage" />} /> {/* Redirect all unknown routes to homepage */}
         </Routes>
       </Suspense>

--- a/app/src/components/playerInterface.ts
+++ b/app/src/components/playerInterface.ts
@@ -1,0 +1,11 @@
+export interface Player {
+    playerId: string;
+    name: string;
+    connection: boolean;
+}
+
+export interface PlayerCanvas {
+    playerName: string;
+    canvas: string;
+    connection: boolean;
+}

--- a/app/src/presenters/homepage-presenter.tsx
+++ b/app/src/presenters/homepage-presenter.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import HomePageView from '../views/homepage';
 import { UserModel } from '../userModel';
 
-import { joinRoom } from '../components/socket-client';
+import { joinRoom, socket } from '../components/socket-client';
+const debug = require('debug')('app:homepage-presenter');
 
 interface HomePageProps {
   model: UserModel;
@@ -14,6 +15,18 @@ const HomePagePresenter: React.FC<HomePageProps> = ({ model }) => {
   const navigate = useNavigate();
   const [isJoinInputVisible, setIsJoinInputVisible] = useState(false);
   const [joinCode, setJoinCode] = useState('');
+
+  useEffect(() => {
+    socket.on('room-joined', (data) => {
+      debug("Room joined:", data.roomId);
+      model.setRoomId(data.roomId);
+      navigate('/player-waiting');
+    });
+
+    return () => {
+      socket.off('room-joined');
+    }
+  }, []);
 
   const handleJoinClick = () => {
     setIsJoinInputVisible(true);
@@ -30,7 +43,6 @@ const HomePagePresenter: React.FC<HomePageProps> = ({ model }) => {
 
     //game logic
     joinRoom(joinCode, "userid", "me");
-    navigate('/player-waiting');
   };
 
   return (

--- a/app/src/presenters/homepage-presenter.tsx
+++ b/app/src/presenters/homepage-presenter.tsx
@@ -20,7 +20,7 @@ const HomePagePresenter: React.FC<HomePageProps> = ({ model }) => {
     socket.on('room-joined', (data) => {
       debug("Room joined:", data.roomId);
       model.setRoomId(data.roomId);
-      navigate('/player-waiting');
+      navigate('/player/game');
     });
 
     return () => {

--- a/app/src/presenters/host-end-presenter.tsx
+++ b/app/src/presenters/host-end-presenter.tsx
@@ -16,7 +16,7 @@ const HostSessionEnd: React.FC<HostSessionEndProps> = ({model}) => {
 
     function onEndGame() {
         closeGame(model.roomId); // Close the socket room if the host ends the game
-        model.resetHost(); // TODO: Reset the model
+        model.reset();
         navigate('/homepage'); // Navigate to the homepage
     }
 

--- a/app/src/presenters/host-game-presenter.tsx
+++ b/app/src/presenters/host-game-presenter.tsx
@@ -42,7 +42,7 @@ const HostGame: React.FC<HostGameProps> = ({model}) => {
   // Navigate to the voting screen when the timer ends
   const handleTimerEnd = useCallback(() => {
     endGame(model.roomId);
-    navigate('/host-voting');
+    navigate('/host/voting');
   }, [model.roomId, navigate]);
 
   return (

--- a/app/src/presenters/host-game-presenter.tsx
+++ b/app/src/presenters/host-game-presenter.tsx
@@ -6,6 +6,7 @@ import HostGameView from '../views/host-game';
 import { UserModel } from '../userModel';
 import { endGame, socket } from '../components/socket-client';
 import Timer from '../components/timer';
+import { PlayerCanvas } from '../components/playerInterface';
 var debug = require('debug')('app:host-game-presenter');
 
 interface HostGameProps {
@@ -18,14 +19,24 @@ const HostGame: React.FC<HostGameProps> = ({model}) => {
    * data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
   */
    const navigate = useNavigate();
-   const [playerCanvas, setCanvas] = useState({}); // Filled with base64-encoded images 
+   const [playerCanvas, setCanvas] = useState<PlayerCanvas[]>([]); // Filled with base64-encoded images 
 
    useEffect(() => {
     // Update when model.updateCanvas is called from player
     socket.on('receive-canvas', (data) => { // Receive a player's canvas
       model.updateCanvas(data.playerId, data.canvas); 
-      setCanvas({playerCanvas, [model.getPlayer(data.playerId)]: data.canvas});
-     });
+      setCanvas([...playerCanvas, {playerName: model.getPlayer(data.playerId), "canvas": data.canvas, "connection": true}]);
+    });
+     socket.on('player-left', async (data) => {  // Player left room
+      model.disconnectedPlayer(data.playerId);
+      debug("Player left mid-game: " + data.playerId);
+      const index = playerCanvas.findIndex(player => player.playerName === model.getPlayer(data.playerId));
+      setCanvas([...playerCanvas.splice(index, 1, {playerName: model.getPlayer(data.playerId), "canvas": "", "connection": false})]);
+    });
+
+    return () => {
+      socket.off('receive-canvas');
+    }
     }, []);
 
   // Navigate to the voting screen when the timer ends
@@ -45,7 +56,6 @@ const HostGame: React.FC<HostGameProps> = ({model}) => {
           />
         }
       />
-      Socket: {socket.id}
       Canvas: {playerCanvas.toString()}
     </div>
   );

--- a/app/src/presenters/host-voting-presenter.tsx
+++ b/app/src/presenters/host-voting-presenter.tsx
@@ -21,6 +21,10 @@ const HostVoting: React.FC<HostVotingProps> = ({model}) => {
                 votingEnded(model.roomId, "results"); // TODO: Process results
             }
         });
+
+        return () => {
+            socket.off('receive-voting');
+        }
     }, []);
     /*
     */

--- a/app/src/presenters/host-waiting-presenter.tsx
+++ b/app/src/presenters/host-waiting-presenter.tsx
@@ -62,7 +62,7 @@ const HostWaiting: React.FC<HostWaitingProps> = ({model}) => {
         /*
         model.updateGame("ocean", [], []);
         startGame(roomCode, model.sessionHost?.playersData); 
-        navigate('/host-ingame'); // Redirect to host-game
+        navigate('/host/ingame'); // Redirect to host-game
         */
         server.getGeneratedSessionParams("").then(startGameACB).catch(handleError);
     }
@@ -94,7 +94,7 @@ const HostWaiting: React.FC<HostWaitingProps> = ({model}) => {
         model.updateGame(sessionParams.real_theme, sessionParams.fake_themes, playerData);
         startGame(roomCode, model.sessionHost?.playersData); 
 
-        navigate('/host-ingame'); // Redirect to host-game
+        navigate('/host/ingame'); // Redirect to host-game
     }
 
     // returns random int, range [0, max)

--- a/app/src/presenters/host-waiting-presenter.tsx
+++ b/app/src/presenters/host-waiting-presenter.tsx
@@ -5,14 +5,10 @@ import { useNavigate } from 'react-router-dom';
 import HostWaitingView from '../views/host-waiting';
 import { UserModel, playerSession } from '../userModel';
 import { hostRoom, startGame, socket } from '../components/socket-client';
+import { Player } from '../components/playerInterface';
 import server from '../server-requests';
-import PlayerSessionEnd from '../views/player-session-end';
-var debug = require('debug')('app:host-waiting-presenter');
 
-export interface Player {
-    playerId: string;
-    name: string;
-  }
+var debug = require('debug')('app:host-waiting-presenter');
 
 interface HostWaitingProps {
     model: UserModel;
@@ -22,9 +18,6 @@ const HostWaiting: React.FC<HostWaitingProps> = ({model}) => {
     const navigate = useNavigate();
     const [players, setPlayers]  = useState<Player[]>([]);
     const [roomCode, setRoomCode] = useState<string>('');
-    
-    debug("Playercount:", model.sessionHost.players.length);
-    debug("Players:", players);
     
     useEffect(() => {
         // Host-side listeners
@@ -38,12 +31,24 @@ const HostWaiting: React.FC<HostWaitingProps> = ({model}) => {
             setPlayers([...model.sessionHost.players]);
             debug('Player joined: ' + data.playerName);
         });
-        socket.on('player-count-error', (data) => { 
+        socket.on('player-left', async (data) => {  // Player left room
+            model.removePlayer(data.playerId); // Should just be removed if player left
+            setPlayers([...model.sessionHost.players]);
+            debug("Player left: " + data.playerId);
+        });
+        socket.on('player-count-error', (data) => { // Player count error from server 
             debug('Player count error, player count at: ' + data.playerCount);
         });
 
         hostRoom();
         model.createHostSession(model.roomId);
+
+        return () => {
+            socket.off('room-created');
+            socket.off('player-joined');
+            socket.off('player-count-error');
+            socket.off('player-left');
+        };
     }, []);
 
     async function startGameHost() { // Callback called when host presses start game
@@ -82,8 +87,8 @@ const HostWaiting: React.FC<HostWaitingProps> = ({model}) => {
                 prompt = sessionParams.real_prompts[real_prompt_count];
                 real_prompt_count++;
             }
-
-            playerData.push({playerId, prompt, role});
+        
+            playerData.push({playerId: playerId, prompt: prompt, role: role, connection: true});
         }
 
         model.updateGame(sessionParams.real_theme, sessionParams.fake_themes, playerData);

--- a/app/src/presenters/player-end-presenter.tsx
+++ b/app/src/presenters/player-end-presenter.tsx
@@ -14,6 +14,10 @@ const PlayerEnd: React.FC<PlayerEndProps> = (model) => {
     socket.on('game-closed', () => { // Receive signal from server/host that game ended
       // TODO: User feedback that host has ended the game
       navigate('/homepage');
+
+      return () => {
+        socket.off('game-closed');
+      }
     });
   }, []); 
 

--- a/app/src/presenters/player-game-presenter.tsx
+++ b/app/src/presenters/player-game-presenter.tsx
@@ -19,6 +19,14 @@ const PlayerGame: React.FC<PlayerGameProps> = ({model}) => {
         socket.on('game-ended', () => { // Receive signal from server/host that game ended
             navigate('/player-voting');
         });
+        socket.on('host-left', () => {  // Host left room
+          model.reset();
+          navigate('/');
+      });
+
+        return () => {
+            socket.off('game-ended');
+        }
     }, []); 
     
     // Popup

--- a/app/src/presenters/player-game-presenter.tsx
+++ b/app/src/presenters/player-game-presenter.tsx
@@ -17,7 +17,7 @@ const PlayerGame: React.FC<PlayerGameProps> = ({model}) => {
     const navigate = useNavigate();
     useEffect(() => {
         socket.on('game-ended', () => { // Receive signal from server/host that game ended
-            navigate('/player-voting');
+            navigate('/player/voting');
         });
         socket.on('host-left', () => {  // Host left room
           model.reset();

--- a/app/src/presenters/player-voting-presenter.tsx
+++ b/app/src/presenters/player-voting-presenter.tsx
@@ -19,6 +19,14 @@ const PlayerVoting: React.FC<PlayerVotingProps> = ({model}) => {
         socket.on('voting-ended', (data) => {  // Voting ended at the end of game
             // model.setResult(data.result); // TODO: Implement setResult in UserModel for player-end
         });
+        socket.on('host-left', () => {  // Host left room
+            model.reset();
+            navigate('/');
+        });
+
+        return () => {
+            socket.off('voting-ended');
+        }
     }, []);
 
     function onVote(votePlayer: string, voteTheme: string) {

--- a/app/src/presenters/player-waiting-presenter.tsx
+++ b/app/src/presenters/player-waiting-presenter.tsx
@@ -17,7 +17,11 @@ const PlayerWaiting: React.FC<PlayerWaitingProps> = ({model}) => {
         socket.on('game-started', (data) => {   // Player game started
             debug("Recieved prompt:", data.prompt);
             model.startGamePlayer(data.prompt);
-            navigate('/player-game');
+            navigate('/player/game');
+        });
+        socket.on('host-left', () => {  // Host left room
+            model.reset();
+            navigate('/');
         });
 
         return () => {

--- a/app/src/presenters/player-waiting-presenter.tsx
+++ b/app/src/presenters/player-waiting-presenter.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 // import components
 import PlayerWaitingView from '../views/player-waiting';
 import { UserModel } from '../userModel';
-import { joinRoom, socket } from '../components/socket-client';
+import { socket } from '../components/socket-client';
 var debug = require('debug')('app:host-game-presenter');
 
 interface PlayerWaitingProps {
@@ -19,13 +19,10 @@ const PlayerWaiting: React.FC<PlayerWaitingProps> = ({model}) => {
             model.startGamePlayer(data.prompt);
             navigate('/player-game');
         });
-        
-        // Error handling, redirect to homepage
-        socket.on('room-not-found', (data) => {
-            debug('Room not found: ' + data.roomId);
-            navigate('/homepage');
-        });
 
+        return () => {
+            socket.off('game-started');
+        };
     },[]);
 
     return <div>

--- a/app/src/userModel.tsx
+++ b/app/src/userModel.tsx
@@ -1,9 +1,5 @@
 import { closeGame } from "./components/socket-client";
-
-export type Player = {
-    playerId: string;
-    name: string;
-}
+import { Player }  from "./components/playerInterface";
 
 export type playerSession = {
     playerId: string;
@@ -57,17 +53,21 @@ export class UserModel {
 
         this.host = true;
         this.roomId = room
-        this.sessionHost = {
-            players: [],
-            playersData: [],
-            theme: "",
-            fake_themes: []
-        };
+        this.reset();
     }
 
-    addPlayer(playerId:string, playerName:string) {
+    addPlayer(playerId:string, playerName:string) { // Add player to host session
         if(this.sessionHost) {
-            this.sessionHost.players.push({"playerId": playerId, "name": playerName});
+            this.sessionHost.players.push({"playerId": playerId, "name": playerName, "connection": true});
+        }
+    }
+
+    removePlayer(playerId:string) { // Remove player from host session
+        if(this.sessionHost) {
+            const playerIndex = this.sessionHost.players.findIndex(player => player.playerId === playerId);
+            if(playerIndex !== -1) {
+                this.sessionHost.players.splice(playerIndex, 1);
+            }
         }
     }
 
@@ -87,6 +87,15 @@ export class UserModel {
             }
         }
         return "None";
+    }
+
+    disconnectedPlayer(playerId:string) { // Set disconnected player's connection to false, use mid-game
+        if(this.sessionHost) {
+            const player = this.sessionHost.players.find(player => player.playerId === playerId);
+            if(player) {
+                player["connection"] = false;
+            }
+        }
     }
 
     updateGame(theme:string, fake_themes:string[], playerData:playerSession[]) { // Update host model theme and players
@@ -110,8 +119,10 @@ export class UserModel {
         // TODO: Implement
     }
 
-    resetHost() {
+    reset() {
         this.host = false;
+        this.sessionHost = {players: [], playersData: [], theme: "", fake_themes: []};
+        this.sessionPlayer = {playerId: "", prompt: "", role: ""};
     }
 
     // Player

--- a/app/src/views/homepage.tsx
+++ b/app/src/views/homepage.tsx
@@ -35,7 +35,7 @@ const HomePage: React.FC<HomePageProps> = ({
       </div>
 
       <div className="absolute bottom-4 left-4 flex space-x-4">
-        <Link to="/host-game" className="text-white bg-green-500 px-4 py-2 rounded hover:bg-green-600 transition">
+        <Link to="/host/game" className="text-white bg-green-500 px-4 py-2 rounded hover:bg-green-600 transition">
           Host Game
         </Link>
         {!isJoinInputVisible ? (

--- a/app/src/views/host-game.tsx
+++ b/app/src/views/host-game.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { PlayerCanvas } from '../components/playerInterface';
 
 interface HostGameViewProps {
-  playerCanvas: {} // Change in presenter to fit Player[]
+  playerCanvas: PlayerCanvas[] // Change in presenter to fit Player[]
   timer: React.ReactNode; // Timer passed from the presenter
 }
 
@@ -18,17 +19,17 @@ const HostGameView: React.FC<HostGameViewProps> = ({ playerCanvas, timer }) => {
 
       {/* Player Canvases */}
       <div className="flex gap-6">
-        {Object.entries(playerCanvas).map(([playerName, canvasData]) => (
-          <div key={playerName} className="flex flex-col items-center">
+        {playerCanvas.map(canvasData => (
+          <div key={canvasData.playerName} className="flex flex-col items-center">
             <div
               className="w-64 h-40 bg-sky-400 rounded-lg mb-2"
               style={{ 
-                backgroundImage: `url(${canvasData})`, 
+                backgroundImage: `url(${canvasData.canvas})`, 
                 backgroundSize: 'cover', 
                 backgroundPosition: 'center' 
               }}
             />
-            <p className="text-lg font-semibold">{playerName}</p>
+            <p className="text-lg font-semibold">{canvasData.playerName}</p>
           </div>
         ))}
       </div>

--- a/app/src/views/host-waiting.tsx
+++ b/app/src/views/host-waiting.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Player } from '../presenters/host-waiting-presenter';
+import { Player } from '../components/playerInterface';
 
 interface HostWaitingProps {
   code: string;


### PR DESCRIPTION
Extends the #44 branch by moving routes, nesting them together for example: `/player-game` --> `/player/game` (Be cautious here that no routes are destroyed, can be reverted if necessary).

Adds a `playerInterface.ts` file that exports interfaces for `Player` and `PlayerCanvas` (used in playerGame) that are reused between presenters and views. `PlayerCanvas` is modified in view and presenter to add a `connection`-key to render players differently depending on whether they leave or not (relevant for @JuliaHallberg?).

Adds events in the `socket.js` and `socket-client.tsx` (and subscribes to the events in relevant presenters) to handle disconnect and perform appropriate action in host/players when one disconnects. For example, all players get redirected back when the host leaves and player is removed in the waiting room when they disconnect. Also updates `UserModel` to accommodate for these changes.

Closes #40 